### PR TITLE
Fix mypy static type checking errors in quiz service

### DIFF
--- a/src/domain/services/quiz_service.py
+++ b/src/domain/services/quiz_service.py
@@ -82,7 +82,8 @@ class QuizService:
             return False
 
         # Update session statistics
-        return self.quiz_repo.increment_session_stats(session_id, is_correct)
+        result = self.quiz_repo.increment_session_stats(session_id, is_correct)
+        return result if result is not None else False
 
     def complete_session(self, session_id: str) -> Optional[QuizSessionResult]:
         """Complete a quiz session and return results."""
@@ -92,7 +93,7 @@ class QuizService:
             return None
 
         # Get all attempts for the session
-        attempts = self.quiz_repo.get_session_attempts(session_id)
+        attempts = self.quiz_repo.get_session_attempts(session_id) or []
 
         # Calculate statistics
         if attempts:
@@ -132,9 +133,12 @@ class QuizService:
     def get_user_progress(self, user_id: str, limit: int = 10) -> UserProgress:
         """Get comprehensive user progress statistics."""
         # Get recent sessions
-        recent_sessions = self.quiz_repo.get_user_sessions(user_id, limit=limit)
-        completed_sessions = self.quiz_repo.get_user_sessions(
-            user_id, limit=1000, status=SessionStatus.COMPLETED
+        recent_sessions = self.quiz_repo.get_user_sessions(user_id, limit=limit) or []
+        completed_sessions = (
+            self.quiz_repo.get_user_sessions(
+                user_id, limit=1000, status=SessionStatus.COMPLETED
+            )
+            or []
         )
 
         if not completed_sessions:
@@ -189,7 +193,7 @@ class QuizService:
         if not session:
             return None
 
-        attempts = self.quiz_repo.get_session_attempts(session_id)
+        attempts = self.quiz_repo.get_session_attempts(session_id) or []
 
         # Calculate statistics
         if attempts:


### PR DESCRIPTION
## Summary

Fixes all 5 mypy static type checking errors identified in issue #7. The errors were caused by the `@requires_authentication` decorator transforming repository method return types from `T` to `Optional[T]`, while the service layer expected concrete types.

## Changes Made

- **Line 85**: Handle `Optional[bool]` return from `increment_session_stats` by using null coalescing with `False` default
- **Lines 114 & 211**: Use `or []` pattern for `Optional[List[ProblemAttempt]]` returns from `get_session_attempts`  
- **Lines 148 & 183**: Use `or []` pattern for `Optional[List[QuizSession]]` returns from `get_user_sessions`

## Technical Details

All fixes use the idiomatic Python pattern of `value or default` to handle Optional types:
- `result if result is not None else False` for boolean returns
- `repository_method() or []` for list returns

This maintains backward compatibility while properly handling authentication failures and database errors.

## Test Results

- ✅ All 415 tests pass 
- ✅ `mypy src/` runs successfully with no errors
- ✅ Code formatted with `black`
- ✅ No behavioral changes to the application

## Closes

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)