### PR TITLE
Remove addition fact normalization to track commutative facts separately

### DIFF
--- a/src/domain/services/addition_fact_service.py
+++ b/src/domain/services/addition_fact_service.py
@@ -20,23 +20,20 @@ class AdditionFactService:
         """
         self.fact_repository = fact_repository
 
-    def normalize_fact_key(self, operand1: int, operand2: int) -> str:
-        """Normalize addition fact to consistent format.
+    def create_fact_key(self, operand1: int, operand2: int) -> str:
+        """Create fact key preserving operand order.
 
-        Always puts the smaller number first for consistency.
-        E.g., both "8+3" and "3+8" become "3+8"
+        Records facts exactly as presented without normalization.
+        E.g., "8+3" and "3+8" are tracked as separate facts.
 
         Args:
             operand1: First operand
             operand2: Second operand
 
         Returns:
-            Normalized fact key string
+            Fact key string preserving operand order
         """
-        if operand1 <= operand2:
-            return f"{operand1}+{operand2}"
-        else:
-            return f"{operand2}+{operand1}"
+        return f"{operand1}+{operand2}"
 
     def track_attempt(
         self,
@@ -60,7 +57,7 @@ class AdditionFactService:
         Returns:
             Updated AdditionFactPerformance or None if error
         """
-        fact_key = self.normalize_fact_key(operand1, operand2)
+        fact_key = self.create_fact_key(operand1, operand2)
 
         return self.fact_repository.upsert_fact_performance(
             user_id=user_id,
@@ -83,7 +80,7 @@ class AdditionFactService:
         Returns:
             AdditionFactPerformance if exists, None otherwise
         """
-        fact_key = self.normalize_fact_key(operand1, operand2)
+        fact_key = self.create_fact_key(operand1, operand2)
         return self.fact_repository.get_user_fact_performance(user_id, fact_key)
 
     def get_weak_facts(
@@ -299,7 +296,7 @@ class AdditionFactService:
             "correct_attempts": correct_attempts,
             "facts_practiced": len(
                 set(
-                    self.normalize_fact_key(op1, op2)
+                    self.create_fact_key(op1, op2)
                     for op1, op2, _, _ in session_attempts
                 )
             ),


### PR DESCRIPTION
## Summary
- Replaces `normalize_fact_key()` with `create_fact_key()` that preserves operand order
- Removes normalization logic that treated `2+3` and `3+2` as the same fact
- Updates all fact tracking methods to use direct fact keys without reordering
- Fixes tests to expect non-normalized behavior where `8+3` ≠ `3+8`

## Problem Solved
Previously, commutative facts like `2+3` and `3+2` were normalized to the same key (`2+3`), causing them to appear twice as practiced compared to identical facts like `4+4`. This created an imbalance in tracking accuracy.

## Changes Made
### Core Service Changes
- **AdditionFactService**: Replaced `normalize_fact_key()` with `create_fact_key()` that preserves operand order
- **Fact Tracking**: All tracking methods now use direct fact keys (e.g., `track_attempt()`, `get_fact_performance()`)
- **Session Analysis**: Updated to count distinct facts without normalization

### Test Updates
- Updated test class name from `TestAdditionFactServiceNormalizeFact` to `TestAdditionFactServiceCreateFactKey`
- Fixed test expectations to match non-normalized behavior
- Updated all method calls to use the new `create_fact_key()` method

## Impact
- **More Accurate Tracking**: Each fact presentation (e.g., `2+3` vs `3+2`) is tracked separately
- **Better User Experience**: Eliminates artificial inflation of practice counts for commutative facts
- **Granular Insights**: Users can see which specific fact presentations need more practice
- **Backward Compatible**: Existing data remains valid, new facts are simply recorded separately

## Test Coverage
- All 467 tests pass
- Type checking with mypy passes
- Code formatting with black applied
- Comprehensive test coverage for the new behavior

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)