### PR TITLE
feat: add --local command-line flag for environment selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,23 @@ This is the entry point for the MathsFun application.
 The actual implementation is in src/presentation/cli/main.py
 """
 
+import argparse
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="MathsFun - Interactive Math Practice Application"
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Use local Docker Supabase environment instead of production",
+    )
+    return parser.parse_args()
+
+
 if __name__ == "__main__":
+    args = parse_args()
     from src.presentation.cli.main import main
-    main()
+    main(use_local=args.local)

--- a/src/presentation/cli/main.py
+++ b/src/presentation/cli/main.py
@@ -148,7 +148,7 @@ def main(use_local: bool = False):
     # Set environment based on command-line flag before any environment detection
     if use_local:
         os.environ["ENVIRONMENT"] = "local"
-    
+
     print_welcome()
 
     while True:  # Outer loop for authentication flow

--- a/src/presentation/cli/main.py
+++ b/src/presentation/cli/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 from .ui import (
     print_welcome,
     print_main_menu,
@@ -142,8 +143,12 @@ def authentication_flow(container):
             print("❌ Invalid option. Please try again.\n")
 
 
-def main():
+def main(use_local: bool = False):
     """Main application loop"""
+    # Set environment based on command-line flag before any environment detection
+    if use_local:
+        os.environ["ENVIRONMENT"] = "local"
+    
     print_welcome()
 
     while True:  # Outer loop for authentication flow

--- a/tests/infrastructure/database/test_environment_config.py
+++ b/tests/infrastructure/database/test_environment_config.py
@@ -71,20 +71,29 @@ class TestEnvironmentConfig:
         mock_response.status_code = 200
         mock_get.return_value = mock_response
 
-        config = EnvironmentConfig(
-            environment="local",
-            url="http://127.0.0.1:54321",
-            anon_key="test-key",
-            is_local=True,
-        )
+        # Mock environment variables to ensure default health endpoint is used
+        with patch.dict(
+            os.environ,
+            {
+                "SUPABASE_HEALTH_ENDPOINT": "/health",  # Use default for test
+                "SUPABASE_HEALTH_TIMEOUT": "5",
+            },
+            clear=False,
+        ):
+            config = EnvironmentConfig(
+                environment="local",
+                url="http://127.0.0.1:54321",
+                anon_key="test-key",
+                is_local=True,
+            )
 
-        is_valid, message, level = config.validate()
+            is_valid, message, level = config.validate()
 
-        assert is_valid is True
-        assert "local development" in message
-        assert level == ValidationLevel.INFO
-        assert "validated" in message
-        mock_get.assert_called_once_with("http://127.0.0.1:54321/health", timeout=5)
+            assert is_valid is True
+            assert "local development" in message
+            assert level == ValidationLevel.INFO
+            assert "validated" in message
+            mock_get.assert_called_once_with("http://127.0.0.1:54321/health", timeout=5)
 
     def test_validate_success_production(self):
         """Test validation with valid production configuration."""

--- a/tests/infrastructure/database/test_supabase_manager.py
+++ b/tests/infrastructure/database/test_supabase_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch, MagicMock
 import threading
 import time
 import os
+import requests
 from http.server import HTTPServer
 from urllib.parse import urlparse, parse_qs
 
@@ -1156,7 +1157,8 @@ class TestSupabaseManagerEnvironmentSwitching:
         # Verify they have different clients pointing to different URLs
         assert prod_manager.config.url != local_manager.config.url
 
-    def test_environment_validation_changes_with_environment(self):
+    @patch("requests.get")
+    def test_environment_validation_changes_with_environment(self, mock_get):
         """Test that validate_environment reflects current environment variables."""
         # Test production validation
         with patch.dict(
@@ -1173,6 +1175,9 @@ class TestSupabaseManagerEnvironmentSwitching:
             assert "production" in message
 
         # Test local validation (will fail health check)
+        # Mock failed health check
+        mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
         with patch.dict(
             os.environ,
             {


### PR DESCRIPTION
## Summary
- Add `--local` command-line flag to override environment configuration
- Enable switching between production and local Docker environments via CLI
- Maintain backward compatibility with existing `.env` file approach

## Changes
- **main.py**: Add argparse for command-line argument parsing with `--local` flag
- **src/presentation/cli/main.py**: Accept `use_local` parameter and set ENVIRONMENT variable

## Usage
- `python main.py` → Uses production database (default behavior)
- `python main.py --local` → Uses local Docker Supabase environment
- `python main.py --help` → Shows available options

## Test plan
- [x] Verify `--help` displays correct usage information
- [x] Confirm default behavior uses production environment
- [x] Test `--local` flag properly sets environment variable
- [x] Ensure existing `.env` file configurations still work

🤖 Generated with [Claude Code](https://claude.ai/code)