### PR TITLE
fix: environment detection now properly switches between production and local

### DIFF
--- a/src/infrastructure/database/environment_config.py
+++ b/src/infrastructure/database/environment_config.py
@@ -100,9 +100,14 @@ class EnvironmentConfig:
         dotenv.load_dotenv()
 
         environment = (os.getenv("ENVIRONMENT") or "production").lower()
+        is_local = environment == "local"
+        
+        # If local environment is requested, load from .env.local (override=True to replace existing values)
+        if is_local:
+            dotenv.load_dotenv(".env.local", override=True)
+        
         url = os.getenv("SUPABASE_URL") or ""
         anon_key = os.getenv("SUPABASE_ANON_KEY") or ""
-        is_local = environment == "local"
 
         return cls(
             environment=environment, url=url, anon_key=anon_key, is_local=is_local

--- a/src/infrastructure/database/environment_config.py
+++ b/src/infrastructure/database/environment_config.py
@@ -101,11 +101,11 @@ class EnvironmentConfig:
 
         environment = (os.getenv("ENVIRONMENT") or "production").lower()
         is_local = environment == "local"
-        
+
         # If local environment is requested, load from .env.local (override=True to replace existing values)
         if is_local:
             dotenv.load_dotenv(".env.local", override=True)
-        
+
         url = os.getenv("SUPABASE_URL") or ""
         anon_key = os.getenv("SUPABASE_ANON_KEY") or ""
 

--- a/tests/infrastructure/database/test_environment_config.py
+++ b/tests/infrastructure/database/test_environment_config.py
@@ -24,12 +24,14 @@ class TestEnvironmentConfig:
             },
             clear=False,
         ):
-            config = EnvironmentConfig.from_environment()
+            # Mock dotenv.load_dotenv to prevent loading from .env.local file
+            with patch("src.infrastructure.database.environment_config.dotenv.load_dotenv"):
+                config = EnvironmentConfig.from_environment()
 
-            assert config.environment == "local"
-            assert config.url == "http://127.0.0.1:54321"
-            assert config.anon_key == "local-key"
-            assert config.is_local is True
+                assert config.environment == "local"
+                assert config.url == "http://127.0.0.1:54321"
+                assert config.anon_key == "local-key"
+                assert config.is_local is True
 
     def test_from_environment_production(self):
         """Test creating config from production environment variables."""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -424,12 +424,14 @@ class TestLocalSupabaseEnvironment:
             },
             clear=False,
         ):
-            is_valid, message = validate_environment()
-            assert is_valid is False
-            assert "Missing SUPABASE_URL or SUPABASE_ANON_KEY" in message
-            assert (
-                "supabase start" in message
-            )  # Local environment specific instructions
+            # Mock dotenv.load_dotenv to prevent loading from .env.local file
+            with patch("src.infrastructure.database.environment_config.dotenv.load_dotenv"):
+                is_valid, message = validate_environment()
+                assert is_valid is False
+                assert "Missing SUPABASE_URL or SUPABASE_ANON_KEY" in message
+                assert (
+                    "supabase start" in message
+                )  # Local environment specific instructions
 
         # Test missing key
         with patch.dict(


### PR DESCRIPTION
## Summary

Fixes environment detection issue where the `--local` flag wasn't properly switching to local database configuration.

**Key Changes:**
- Modified `EnvironmentConfig.from_environment()` to automatically load `.env.local` when `ENVIRONMENT=local`
- Added `override=True` to ensure local configuration takes precedence over production values
- Updated `.env` file with actual production Supabase credentials
- Fixed related tests to properly mock environment loading behavior

**Behavior Changes:**
- **Default behavior** (no flag): Uses production Supabase at `https://swlrhvurbubfplfeoqeg.supabase.co`
- **With `--local` flag**: Uses local Supabase at `http://127.0.0.1:54321`

## Test plan

- [x] All existing tests pass (548 tests)
- [x] mypy type checking passes
- [x] black code formatting applied
- [x] Manual testing of both environment scenarios
- [x] Console messages display correct environment information

🤖 Generated with [Claude Code](https://claude.ai/code)